### PR TITLE
Feature/101 auto stop conference

### DIFF
--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -132,7 +132,7 @@ export class MailService {
     });
   }
 
-  @OnEvent(ApplicationEvent.MEETING_END)
+  @OnEvent(ApplicationEvent.CONFERENCE_STOPPED)
   public async sendMeetingSummary(bubble: Bubble): Promise<void> {
     const meeting = await this.meetingService.findMeetingByBubbleId(bubble.id);
     const messages = await this.meetingService.getMessages(meeting);

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -281,7 +281,7 @@ export class MeetingsService {
     });
   }
 
-  @OnEvent(ApplicationEvent.MEETING_END)
+  @OnEvent(ApplicationEvent.CONFERENCE_STOPPED)
   /**
    * Ends a meeting by updating its status and marking it as finished.
    * @param meeting - The meeting to be ended.

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -268,6 +268,23 @@ export class MeetingsService {
     await this.rainbow.callBubble(bubble);
   }
 
+  @OnEvent(ApplicationEvent.MEETING_END)
+  /**
+   * Hangs up a meeting bubble.
+   * @param meeting - The meeting object.
+   * @returns A promise that resolves when the bubble is hung up.
+   */
+  public async hangupMeetingBubble(
+    meeting: MeetingWithAttendees,
+  ): Promise<void> {
+    // Retrieve the meeting data to load the bubble ID
+    const meetingData = await this.findOne(meeting.id);
+
+    this.logger.debug(`Hanging up bubble for meeting "${meetingData.id}"`);
+    const bubble = this.rainbow.getBubbleByID(meetingData.bubbleId);
+    await this.rainbow.hangupBubble(bubble);
+  }
+
   @OnEvent(ApplicationEvent.CONFERENCE_STARTED)
   /**
    * Starts a meeting by updating its status and marking it as started.

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -205,12 +205,15 @@ export class MeetingsService {
           })),
         },
       },
+      include: {
+        attendees: true,
+      },
     });
 
     this._meetings.next({
       type: 'updated',
       id: meeting.id,
-      meeting: await this.findOneWithAttendees(meeting.id),
+      meeting,
     });
     this.eventEmitter.emit(ApplicationEvent.MEETING_UPDATE, meeting);
     return meeting;
@@ -252,23 +255,31 @@ export class MeetingsService {
 
   @OnEvent(ApplicationEvent.MEETING_START)
   /**
-   * Starts a meeting.
+   * Calls a meeting bubble.
    * @param meeting - The meeting object.
-   * @returns A promise that resolves when the meeting has started.
+   * @returns A promise that resolves when the bubble is called.
    */
-  public async startMeeting(meeting: MeetingWithAttendees): Promise<void> {
-    this.logger.debug(`Starting meeting "${meeting.id}"`);
+  public async callMeetingBubble(meeting: MeetingWithAttendees): Promise<void> {
+    // Retrieve the meeting data to load the bubble ID
+    const meetingData = await this.findOne(meeting.id);
 
-    const meetingData = await this.database.meeting.findUniqueOrThrow({
-      where: { id: meeting.id },
-      include: { attendees: true },
-    });
-
+    this.logger.debug(`Calling bubble for meeting "${meetingData.id}"`);
     const bubble = this.rainbow.getBubbleByID(meetingData.bubbleId);
-
     await this.rainbow.callBubble(bubble);
+  }
+
+  @OnEvent(ApplicationEvent.CONFERENCE_STARTED)
+  /**
+   * Starts a meeting by updating its status and marking it as started.
+   * @param meeting - The meeting to be started.
+   * @returns A promise that resolves when the meeting has been successfully started.
+   */
+  public async startMeeting(bubble: Bubble): Promise<void> {
+    const meeting = await this.findMeetingByBubbleId(bubble.id);
+    if (!meeting) return;
 
     // Update the meeting status
+    this.logger.debug(`Starting meeting "${meeting.id}"`);
     await this.database.meeting.update({
       where: { id: meeting.id },
       data: { status: MeetingStatus.STARTED },
@@ -276,8 +287,8 @@ export class MeetingsService {
 
     this._meetings.next({
       type: 'started',
-      id: meetingData.id,
-      url: meetingData.publicUrl,
+      id: meeting.id,
+      url: meeting.publicUrl,
     });
   }
 

--- a/src/rainbow/rainbow.service.ts
+++ b/src/rainbow/rainbow.service.ts
@@ -68,14 +68,14 @@ export class RainbowService implements OnApplicationShutdown {
     this.rainbowSDK.events.on(
       'rainbow_onbubbleconferencestoppedreceived',
       (bubble: Bubble) => {
-        this.eventEmitter.emit(ApplicationEvent.MEETING_END, bubble);
+        this.eventEmitter.emit(ApplicationEvent.CONFERENCE_STOPPED, bubble);
       },
     );
 
     this.rainbowSDK.events.on(
       'rainbow_onbubbleconferencestartedreceived',
       (bubble: Bubble) => {
-        this.eventEmitter.emit(ApplicationEvent.MEETING_CANCEL_END, bubble);
+        this.eventEmitter.emit(ApplicationEvent.CONFERENCE_STARTED, bubble);
       },
     );
   }

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -89,7 +89,7 @@ export class SchedulerService {
     );
   }
 
-  @OnEvent(ApplicationEvent.MEETING_END)
+  @OnEvent(ApplicationEvent.CONFERENCE_STOPPED)
   /**
    * Schedules bubble cleaning for a given bubble.
    * @param bubble - The bubble to schedule cleaning for.
@@ -114,14 +114,19 @@ export class SchedulerService {
     );
   }
 
-  @OnEvent(ApplicationEvent.MEETING_CANCEL_END)
+  @OnEvent(ApplicationEvent.CONFERENCE_STARTED)
   /**
    * Cancels the bubble cleaning for a given bubble.
    * @param bubble - The bubble for which the cleaning is to be canceled.
    * @returns A promise that resolves when the cleaning is canceled.
    */
   public async cancelBubbleCleaning(bubble: Bubble): Promise<void> {
-    this.schedulerRegistry.deleteCronJob(`bubble-${bubble.id}-cleaning`);
+    if (
+      this.schedulerRegistry.doesExist('cron', `bubble-${bubble.id}-cleaning`)
+    ) {
+      this.logger.debug(`Canceling bubble cleaning for id ${bubble.id}`);
+      this.schedulerRegistry.deleteCronJob(`bubble-${bubble.id}-cleaning`);
+    }
   }
 
   /**

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -89,6 +89,25 @@ export class SchedulerService {
     );
   }
 
+  @OnEvent(ApplicationEvent.MEETING_CREATE)
+  /**
+   * Schedules the end of a bubble for a meeting.
+   * @param meeting - The meeting with attendees.
+   * @returns A Promise that resolves when the bubble end is scheduled.
+   */
+  public async scheduleBubbleEnd(meeting: MeetingWithAttendees): Promise<void> {
+    const bubbleEndDate = new Date(meeting.end_date);
+    const endJob = new CronJob(bubbleEndDate, async () => {
+      this.eventEmitter.emit(ApplicationEvent.MEETING_END, meeting);
+    });
+    endJob.start();
+
+    this.schedulerRegistry.addCronJob(
+      `meeting-${meeting.id}-bubble-end`,
+      endJob,
+    );
+  }
+
   @OnEvent(ApplicationEvent.CONFERENCE_STOPPED)
   /**
    * Schedules bubble cleaning for a given bubble.
@@ -139,6 +158,7 @@ export class SchedulerService {
     meetings.forEach(async (meeting) => {
       this.scheduleBubbleCreation(meeting);
       this.scheduleBubbleStart(meeting);
+      this.scheduleBubbleEnd(meeting);
     });
   }
 }

--- a/src/types/MeetingEvents.ts
+++ b/src/types/MeetingEvents.ts
@@ -28,11 +28,6 @@ export enum ApplicationEvent {
   MEETING_END = 'meeting.end',
 
   /**
-   * Event triggered when the end of a meeting is canceled.
-   */
-  MEETING_CANCEL_END = 'meeting.cancelEnd',
-
-  /**
    * Event triggered before a meeting starts.
    */
   MEETING_BEFORE_START = 'meeting.beforeStart',
@@ -41,4 +36,14 @@ export enum ApplicationEvent {
    * Event triggered for meeting cleaning.
    */
   MEETING_CLEANING = 'meeting.cleaning',
+
+  /**
+   * Event triggered when a conference is started.
+   */
+  CONFERENCE_STARTED = 'conference.started',
+
+  /**
+   * Event triggered when a conference is stopped.
+   */
+  CONFERENCE_STOPPED = 'conference.stopped',
 }


### PR DESCRIPTION
Close #101 

For now, conference is stopped at `meeting.end_date`. Tested it and works finely, including meeting summary email.
When we will correctly handle meeting update, we will check if people are still in the conference and if so, update `meeting.end_date`.